### PR TITLE
Updated generate.sh scripts to use all cores, fixed build error on ubuntu

### DIFF
--- a/dji-flightrecord-kit/build/Ubuntu/FRSample/generate.sh
+++ b/dji-flightrecord-kit/build/Ubuntu/FRSample/generate.sh
@@ -4,5 +4,5 @@ executableSourceFolder="../../../source/FRSample"
 echo "Which do you want to build? Please Input the number: "
 
 cmake -D platform=${platform} -DENABLE_SHARED_LIB=false ${executableSourceFolder}
-make
+make -j$(nproc)
 

--- a/dji-flightrecord-kit/build/Ubuntu/FlightRecordStandardizationCpp/generate.sh
+++ b/dji-flightrecord-kit/build/Ubuntu/FlightRecordStandardizationCpp/generate.sh
@@ -4,4 +4,4 @@ sourceFolder="../../../source/FlightRecordStandardizationCpp"
 echo "Which do you want to build? Please Input the number: "
 
 cmake -D platform=${platform} -DENABLE_SHARED_LIB=false ${sourceFolder}
-make
+make -j$(nproc)

--- a/dji-flightrecord-kit/source/FlightRecordStandardization/model/common/fr_standardization_common.cpp
+++ b/dji-flightrecord-kit/source/FlightRecordStandardization/model/common/fr_standardization_common.cpp
@@ -7,6 +7,7 @@
 
 #include "fr_standardization_common.hpp"
 #include <string.h>
+#include <cstdlib>
 
 using namespace DJIFR::standardization;
 


### PR DESCRIPTION
Added `nproc` to `generate.sh`. This will use all available cores to improve build speeds.

Fixed issue #1 where there is a compile error due to missing imports.